### PR TITLE
Update GUI save workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ python word_copywriter.py
 
 1. Select the source document containing key-value pairs (lines formatted as `Key: Value`).
 2. Select the template document with placeholders like `{{Key}}`.
-3. Choose where to save the resulting document and press **Copy**.
+3. After selecting source and template, press **Save** and choose where to store the resulting document.
 
 The resulting document will be created with the placeholders replaced by the values from the source document.

--- a/word_copywriter.py
+++ b/word_copywriter.py
@@ -42,6 +42,7 @@ class MainWindow(QtWidgets.QWidget):
 
         # Source document
         self.source_edit = QtWidgets.QLineEdit()
+        self.source_edit.setReadOnly(True)
         source_btn = QtWidgets.QPushButton("Browse")
         source_btn.clicked.connect(self.browse_source)
         layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
@@ -50,22 +51,18 @@ class MainWindow(QtWidgets.QWidget):
 
         # Template document
         self.template_edit = QtWidgets.QLineEdit()
+        self.template_edit.setReadOnly(True)
         template_btn = QtWidgets.QPushButton("Browse")
         template_btn.clicked.connect(self.browse_template)
         layout.addWidget(QtWidgets.QLabel("Template"), 0, 1)
         layout.addWidget(self.template_edit, 1, 1)
         layout.addWidget(template_btn, 2, 1)
 
-        # Output path and copy button
-        self.output_edit = QtWidgets.QLineEdit()
-        output_btn = QtWidgets.QPushButton("Browse")
-        output_btn.clicked.connect(self.browse_output)
-        copy_btn = QtWidgets.QPushButton("Copy")
-        copy_btn.clicked.connect(self.copy_data)
-        layout.addWidget(QtWidgets.QLabel("Output"), 0, 2)
-        layout.addWidget(self.output_edit, 1, 2)
-        layout.addWidget(output_btn, 2, 2)
-        layout.addWidget(copy_btn, 3, 1)
+        # Save button
+        self.save_btn = QtWidgets.QPushButton("Save")
+        self.save_btn.clicked.connect(self.save_document)
+        self.save_btn.setEnabled(False)
+        layout.addWidget(self.save_btn, 3, 1)
 
         self.setLayout(layout)
 
@@ -73,31 +70,36 @@ class MainWindow(QtWidgets.QWidget):
         path, _ = QFileDialog.getOpenFileName(self, "Select source", filter="Word Documents (*.docx)")
         if path:
             self.source_edit.setText(path)
+        self.update_save_button_state()
 
     def browse_template(self):
         path, _ = QFileDialog.getOpenFileName(self, "Select template", filter="Word Documents (*.docx)")
         if path:
             self.template_edit.setText(path)
+        self.update_save_button_state()
 
-    def browse_output(self):
-        path, _ = QFileDialog.getSaveFileName(self, "Save document", filter="Word Documents (*.docx)")
-        if path:
-            if not path.lower().endswith('.docx'):
-                path += '.docx'
-            self.output_edit.setText(path)
-
-    def copy_data(self):
+    def save_document(self):
         source_path = self.source_edit.text()
         template_path = self.template_edit.text()
-        output_path = self.output_edit.text()
-        if not (source_path and template_path and output_path):
-            QMessageBox.warning(self, "Warning", "Please select all files")
+        if not (source_path and template_path):
+            QMessageBox.warning(self, "Warning", "Please select source and template files")
             return
+        output_path, _ = QFileDialog.getSaveFileName(self, "Save document", filter="Word Documents (*.docx)")
+        if not output_path:
+            return
+        if not output_path.lower().endswith('.docx'):
+            output_path += '.docx'
         data = read_data_from_docx(source_path)
         doc = Document(template_path)
         replace_placeholders(doc, data)
         doc.save(output_path)
         QMessageBox.information(self, "Success", f"Document saved to {output_path}")
+
+    def update_save_button_state(self):
+        if self.source_edit.text() and self.template_edit.text():
+            self.save_btn.setEnabled(True)
+        else:
+            self.save_btn.setEnabled(False)
 
 
 def main():


### PR DESCRIPTION
## Summary
- update GUI to use a **Save** button instead of a **Copy** button
- disable editing of file paths and enable the **Save** button only when both files are chosen
- update logic to ask for output path on save
- refresh README instructions

## Testing
- `python -m py_compile word_copywriter.py`


------
https://chatgpt.com/codex/tasks/task_e_688c8c8b23f8832787163c175dedcd5b