### PR TITLE
Refactor script into modular entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install requirements and run the application:
 
 ```bash
 pip install -r requirements.txt
-python word_copywriter.py
+python main.py
 ```
 
 1. Select the source document containing key-value pairs (lines formatted as `Key: Value`). PDF files are supported, including scanned documents (requires `tesseract` and `poppler` installed).

--- a/doc_utils.py
+++ b/doc_utils.py
@@ -1,0 +1,29 @@
+def replace_placeholders(doc, data):
+    """Replace placeholders in doc with values from data."""
+    for para in doc.paragraphs:
+        for run in para.runs:
+            for key, value in data.items():
+                placeholder = f"{{{{{key}}}}}"
+                if placeholder in run.text:
+                    run.text = run.text.replace(placeholder, value)
+    for table in doc.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                replace_placeholders(cell, data)
+
+
+def format_preview(data):
+    """Return formatted string for preview widget."""
+    lines = [
+        data.get("Данные заказчика", ""),
+        data.get("ИНН получателя", ""),
+        data.get("ОГРН получателя", ""),
+        f"Транспортные услуги по договору-заявке {data.get('Номер документа', '')}",
+        f"По маршруту {data.get('Адрес загрузки', '')} - {data.get('Адрес разгрузки', '')}",
+        f"Автомобиль: {data.get('Марка автомобиля', '')} {data.get('Номер полуприцепа', '')}",
+        f"Водитель: {data.get('ФИО водителя', '')}",
+        f"Дата погрузки: {data.get('Дата погрузки', '')}",
+        f"Дата разгрузки: {data.get('Дата разгрузки', '')}",
+        f"Стоимость перевозки: {data.get('Стоимость перевозки', '')}",
+    ]
+    return "\n".join(lines)

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,98 @@
+from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QFileDialog, QMessageBox
+from docx import Document
+
+from parsers import read_data_from_file
+from doc_utils import format_preview, replace_placeholders
+
+
+class MainWindow(QtWidgets.QWidget):
+    def __init__(self):
+        super().__init__()
+        self.data = {}
+        self.init_ui()
+
+    def init_ui(self):
+        self.setWindowTitle("Word Copywriter")
+        layout = QtWidgets.QGridLayout()
+
+        # Source document
+        self.source_edit = QtWidgets.QLineEdit()
+        self.source_edit.setReadOnly(True)
+        source_btn = QtWidgets.QPushButton("Browse")
+        source_btn.clicked.connect(self.browse_source)
+        layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
+        layout.addWidget(self.source_edit, 1, 0)
+        layout.addWidget(source_btn, 2, 0)
+        self.preview_edit = QtWidgets.QTextEdit()
+        self.preview_edit.setReadOnly(True)
+        layout.addWidget(self.preview_edit, 3, 0)
+
+        # Template document
+        self.template_edit = QtWidgets.QLineEdit()
+        self.template_edit.setReadOnly(True)
+        template_btn = QtWidgets.QPushButton("Browse")
+        template_btn.clicked.connect(self.browse_template)
+        layout.addWidget(QtWidgets.QLabel("Template"), 0, 1)
+        layout.addWidget(self.template_edit, 1, 1)
+        layout.addWidget(template_btn, 2, 1)
+
+        # Save button
+        self.save_btn = QtWidgets.QPushButton("Save")
+        self.save_btn.clicked.connect(self.save_document)
+        self.save_btn.setEnabled(False)
+        layout.addWidget(self.save_btn, 3, 1)
+
+        self.setLayout(layout)
+
+    def browse_source(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select source", filter="Documents (*.docx *.pdf)"
+        )
+        if path:
+            self.source_edit.setText(path)
+            self.data = read_data_from_file(path)
+            self.preview_edit.setPlainText(format_preview(self.data))
+        self.update_save_button_state()
+
+    def browse_template(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Select template", filter="Word Documents (*.docx)")
+        if path:
+            self.template_edit.setText(path)
+        self.update_save_button_state()
+
+    def save_document(self):
+        source_path = self.source_edit.text()
+        template_path = self.template_edit.text()
+        if not (source_path and template_path):
+            QMessageBox.warning(self, "Warning", "Please select source and template files")
+            return
+        output_path, _ = QFileDialog.getSaveFileName(self, "Save document", filter="Word Documents (*.docx)")
+        if not output_path:
+            return
+        if not output_path.lower().endswith('.docx'):
+            output_path += '.docx'
+        data = getattr(self, 'data', None)
+        if not data:
+            data = read_data_from_file(source_path)
+        doc = Document(template_path)
+        replace_placeholders(doc, data)
+        try:
+            doc.save(output_path)
+            QMessageBox.information(self, "Success", f"Document saved to {output_path}")
+        except PermissionError:
+            QMessageBox.critical(
+                self,
+                "Error",
+                "Cannot save file. It may be open in another program.",
+            )
+            return
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save file: {e}")
+            return
+
+    def update_save_button_state(self):
+        if self.source_edit.text() and self.template_edit.text():
+            self.save_btn.setEnabled(True)
+        else:
+            self.save_btn.setEnabled(False)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,15 @@
+import sys
+from PyQt5 import QtWidgets
+
+from gui import MainWindow
+
+
+def main():
+    app = QtWidgets.QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    main()

--- a/parsers.py
+++ b/parsers.py
@@ -1,12 +1,8 @@
-import sys
-from PyQt5 import QtWidgets
-from PyQt5.QtWidgets import QFileDialog, QMessageBox
-from docx import Document
 import re
+from docx import Document
 import pdfplumber
 from pdf2image import convert_from_path
 import pytesseract
-
 
 DEFAULT_DATA = {
     "Данные заказчика": "",
@@ -33,7 +29,7 @@ def read_data_from_docx(path):
     # First paragraph with number
     for para in doc.paragraphs:
         text = para.text.strip()
-        if text.startswith("Договор-заявка"):# and text.endswith("года ."):
+        if text.startswith("Договор-заявка"):
             num_start = text.find("№")
             if num_start != -1:
                 data["Номер документа"] = text[num_start:].strip()
@@ -81,7 +77,6 @@ def read_data_from_docx(path):
                 data["ОГРН получателя"] = ogrn_match.group(0).strip()
 
     return data
-
 
 
 def parse_data_from_text(text: str):
@@ -215,7 +210,6 @@ def parse_data_from_text(text: str):
     return data
 
 
-
 def extract_text_from_pdf(path: str) -> str:
     """Extract text from PDF, using OCR for scanned documents."""
     text = ""
@@ -245,137 +239,3 @@ def read_data_from_file(path: str):
     if path.lower().endswith(".pdf"):
         return read_data_from_pdf(path)
     raise ValueError("Unsupported file format")
-
-
-def replace_placeholders(doc, data):
-    """Replace placeholders in doc with values from data."""
-    for para in doc.paragraphs:
-        for run in para.runs:
-            for key, value in data.items():
-                placeholder = f"{{{{{key}}}}}"
-                if placeholder in run.text:
-                    run.text = run.text.replace(placeholder, value)
-    for table in doc.tables:
-        for row in table.rows:
-            for cell in row.cells:
-                replace_placeholders(cell, data)
-
-
-def format_preview(data):
-    """Return formatted string for preview widget."""
-    lines = [
-        data.get("Данные заказчика", ""),
-        data.get("ИНН получателя", ""),
-        data.get("ОГРН получателя", ""),
-        f"Транспортные услуги по договору-заявке {data.get('Номер документа', '')}",
-        f"По маршруту {data.get('Адрес загрузки', '')} - {data.get('Адрес разгрузки', '')}",
-        f"Автомобиль: {data.get('Марка автомобиля', '')} {data.get('Номер полуприцепа', '')}",
-        f"Водитель: {data.get('ФИО водителя', '')}",
-        f"Дата погрузки: {data.get('Дата погрузки', '')}",
-        f"Дата разгрузки: {data.get('Дата разгрузки', '')}",
-        f"Стоимость перевозки: {data.get('Стоимость перевозки', '')}",
-    ]
-    return "\n".join(lines)
-
-
-class MainWindow(QtWidgets.QWidget):
-    def __init__(self):
-        super().__init__()
-        self.data = {}
-        self.init_ui()
-
-    def init_ui(self):
-        self.setWindowTitle("Word Copywriter")
-        layout = QtWidgets.QGridLayout()
-
-        # Source document
-        self.source_edit = QtWidgets.QLineEdit()
-        self.source_edit.setReadOnly(True)
-        source_btn = QtWidgets.QPushButton("Browse")
-        source_btn.clicked.connect(self.browse_source)
-        layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
-        layout.addWidget(self.source_edit, 1, 0)
-        layout.addWidget(source_btn, 2, 0)
-        self.preview_edit = QtWidgets.QTextEdit()
-        self.preview_edit.setReadOnly(True)
-        layout.addWidget(self.preview_edit, 3, 0)
-
-        # Template document
-        self.template_edit = QtWidgets.QLineEdit()
-        self.template_edit.setReadOnly(True)
-        template_btn = QtWidgets.QPushButton("Browse")
-        template_btn.clicked.connect(self.browse_template)
-        layout.addWidget(QtWidgets.QLabel("Template"), 0, 1)
-        layout.addWidget(self.template_edit, 1, 1)
-        layout.addWidget(template_btn, 2, 1)
-
-        # Save button
-        self.save_btn = QtWidgets.QPushButton("Save")
-        self.save_btn.clicked.connect(self.save_document)
-        self.save_btn.setEnabled(False)
-        layout.addWidget(self.save_btn, 3, 1)
-
-        self.setLayout(layout)
-
-    def browse_source(self):
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Select source", filter="Documents (*.docx *.pdf)"
-        )
-        if path:
-            self.source_edit.setText(path)
-            self.data = read_data_from_file(path)
-            self.preview_edit.setPlainText(format_preview(self.data))
-        self.update_save_button_state()
-
-    def browse_template(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Select template", filter="Word Documents (*.docx)")
-        if path:
-            self.template_edit.setText(path)
-        self.update_save_button_state()
-
-    def save_document(self):
-        source_path = self.source_edit.text()
-        template_path = self.template_edit.text()
-        if not (source_path and template_path):
-            QMessageBox.warning(self, "Warning", "Please select source and template files")
-            return
-        output_path, _ = QFileDialog.getSaveFileName(self, "Save document", filter="Word Documents (*.docx)")
-        if not output_path:
-            return
-        if not output_path.lower().endswith('.docx'):
-            output_path += '.docx'
-        data = getattr(self, 'data', None)
-        if not data:
-            data = read_data_from_file(source_path)
-        doc = Document(template_path)
-        replace_placeholders(doc, data)
-        try:
-            doc.save(output_path)
-            QMessageBox.information(self, "Success", f"Document saved to {output_path}")
-        except PermissionError:
-            QMessageBox.critical(
-                self,
-                "Error",
-                "Cannot save file. It may be open in another program."
-            )
-            return
-        except Exception as e:
-            QMessageBox.critical(self, "Error", f"Failed to save file: {e}")
-            return
-
-    def update_save_button_state(self):
-        if self.source_edit.text() and self.template_edit.text():
-            self.save_btn.setEnabled(True)
-        else:
-            self.save_btn.setEnabled(False)
-
-
-def main():
-    app = QtWidgets.QApplication(sys.argv)
-    window = MainWindow()
-    window.show()
-    sys.exit(app.exec_())
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- Break the previous monolithic script into dedicated modules for parsing, utilities and GUI
- Introduce `main.py` as the application entry point
- Update README instructions to use the new entry script

## Testing
- `python -m py_compile main.py gui.py parsers.py doc_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_688df1dcf1a48327b15111c30e438718