### PR TITLE
Fix indentation in create_document

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -134,7 +134,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if not (template_bytes and source_path):
             QMessageBox.warning(self, "Warning", "Please select source and templates")
             return
-         output_path, _ = QFileDialog.getSaveFileName(
+        output_path, _ = QFileDialog.getSaveFileName(
             self, "Save document", filter="Excel Files (*.xlsx)"
         )
         if not output_path:


### PR DESCRIPTION
## Summary
- fix misaligned output path line in `create_document`
- ensure consistent 4-space indentation after template and source check

## Testing
- `python -m py_compile gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d60777908327af61253448ca7136