### PR TITLE
Support xls templates in generator

### DIFF
--- a/excel_utils.py
+++ b/excel_utils.py
@@ -1,0 +1,40 @@
+from io import BytesIO
+from openpyxl import load_workbook, Workbook
+import xlrd
+import xlwt
+
+
+def replace_placeholders(wb, data):
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for cell in row:
+                if isinstance(cell.value, str):
+                    for key, value in data.items():
+                        placeholder = f"{{{{{key}}}}}"
+                        if placeholder in cell.value:
+                            cell.value = cell.value.replace(placeholder, value)
+
+
+def create_document(template_bytes, ext, data, output_path):
+    if ext == ".xls":
+        book = xlrd.open_workbook(file_contents=template_bytes)
+        wb = Workbook()
+        wb.remove(wb.active)
+        for sheet in book.sheets():
+            ws = wb.create_sheet(title=sheet.name)
+            for r in range(sheet.nrows):
+                for c in range(sheet.ncols):
+                    ws.cell(row=r + 1, column=c + 1, value=sheet.cell_value(r, c))
+    else:
+        wb = load_workbook(BytesIO(template_bytes))
+    replace_placeholders(wb, data)
+    if output_path.lower().endswith(".xls"):
+        out_wb = xlwt.Workbook()
+        for ws in wb.worksheets:
+            out_ws = out_wb.add_sheet(ws.title[:31])
+            for r_idx, row in enumerate(ws.iter_rows(values_only=True)):
+                for c_idx, value in enumerate(row):
+                    out_ws.write(r_idx, c_idx, value)
+        out_wb.save(output_path)
+    else:
+        wb.save(output_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ PyQt5>=5.15
 pdfplumber>=0.9
 pdf2image>=1.16
 pytesseract>=0.3
+xlrd>=2.0
+xlwt>=1.3


### PR DESCRIPTION
## Summary
- add xlrd and xlwt dependencies for legacy `.xls` support
- handle `.xls` templates and allow saving as `.xls` or `.xlsx`
- separate document generation logic from GUI into `excel_utils`

## Testing
- `python -m py_compile gui.py main.py doc_utils.py parsers.py excel_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e8413560832787be042cdf428114