### PR TITLE
Preserve Excel cell formatting during placeholder replacement

### DIFF
--- a/excel_utils.py
+++ b/excel_utils.py
@@ -29,7 +29,9 @@ def replace_placeholders(wb, data):
                             if placeholder in new_value:
                                 new_value = new_value.replace(placeholder, value)
                         if new_value != cell_value:
-                            ws.write(r, c, new_value)
+                            style = xlwt.XFStyle()
+                            style.xf_idx = sheet.cell_xf_index(r, c)
+                            ws.write(r, c, new_value, style)
     else:
         raise TypeError("Unsupported workbook type")
 


### PR DESCRIPTION
## Summary
- Preserve cell formatting when replacing placeholders in `.xls` workbooks by applying original styles

## Testing
- `python -m py_compile excel_utils.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892091835d4832784a934488f7c31e9