### PR TITLE
Fix Excel template conversions and preserve formatting

### DIFF
--- a/excel_utils.py
+++ b/excel_utils.py
@@ -1,3 +1,4 @@
+import os
 from io import BytesIO
 from openpyxl import load_workbook, Workbook
 import xlrd
@@ -19,6 +20,8 @@ def replace_placeholders(wb, data):
         book = getattr(wb, "_xlrd_book")
         for idx, sheet in enumerate(book.sheets()):
             ws = wb.get_sheet(idx)
+            merged = list(sheet.merged_cells)
+            handled = set()
             for r in range(sheet.nrows):
                 for c in range(sheet.ncols):
                     cell_value = sheet.cell_value(r, c)
@@ -31,17 +34,77 @@ def replace_placeholders(wb, data):
                         if new_value != cell_value:
                             style = xlwt.XFStyle()
                             style.xf_idx = sheet.cell_xf_index(r, c)
-                            ws.write(r, c, new_value, style)
+                            merged_range = None
+                            for rng in merged:
+                                rlo, rhi, clo, chi = rng
+                                if rlo <= r < rhi and clo <= c < chi:
+                                    merged_range = rng
+                                    break
+                            if merged_range and merged_range not in handled:
+                                rlo, rhi, clo, chi = merged_range
+                                ws.write_merge(rlo, rhi - 1, clo, chi - 1, new_value, style)
+                                handled.add(merged_range)
+                            else:
+                                ws.write(r, c, new_value, style)
     else:
         raise TypeError("Unsupported workbook type")
 
 
+def xlrd_to_openpyxl(book):
+    wb = Workbook()
+    wb.remove(wb.active)
+    for sheet in book.sheets():
+        ws = wb.create_sheet(sheet.name)
+        for r in range(sheet.nrows):
+            for c in range(sheet.ncols):
+                value = sheet.cell_value(r, c)
+                if value != "":
+                    ws.cell(row=r + 1, column=c + 1, value=value)
+        for rlo, rhi, clo, chi in sheet.merged_cells:
+            ws.merge_cells(start_row=rlo + 1, end_row=rhi, start_column=clo + 1, end_column=chi)
+    return wb
+
+
+def openpyxl_to_xlwt(wb):
+    book = xlwt.Workbook()
+    for ws in wb.worksheets:
+        sheet = book.add_sheet(ws.title)
+        for r, row in enumerate(ws.iter_rows(values_only=True)):
+            for c, value in enumerate(row):
+                if value is not None:
+                    sheet.write(r, c, value)
+        for rng in ws.merged_cells.ranges:
+            rlo = rng.min_row - 1
+            rhi = rng.max_row - 1
+            clo = rng.min_col - 1
+            chi = rng.max_col - 1
+            top_left = ws.cell(rng.min_row, rng.min_col).value
+            sheet.write_merge(rlo, rhi, clo, chi, top_left)
+    return book
+
+
 def create_document(template_bytes, ext, data, output_path):
+    out_ext = os.path.splitext(output_path)[1].lower()
     if ext == ".xls":
         book = xlrd.open_workbook(file_contents=template_bytes, formatting_info=True)
-        wb = xl_copy(book)
-        wb._xlrd_book = book
+        if out_ext == ".xls":
+            wb = xl_copy(book)
+            wb._xlrd_book = book
+            replace_placeholders(wb, data)
+            wb.save(output_path)
+        else:
+            wb = xlrd_to_openpyxl(book)
+            replace_placeholders(wb, data)
+            for ws in wb.worksheets:
+                ws.sheet_state = "visible"
+            wb.save(output_path)
     else:
         wb = load_workbook(BytesIO(template_bytes))
-    replace_placeholders(wb, data)
-    wb.save(output_path)
+        replace_placeholders(wb, data)
+        for ws in wb.worksheets:
+            ws.sheet_state = "visible"
+        if out_ext == ".xls":
+            book = openpyxl_to_xlwt(wb)
+            book.save(output_path)
+        else:
+            wb.save(output_path)


### PR DESCRIPTION
## Summary
- Preserve formatting in .xls templates by handling merged cells when replacing placeholders
- Add conversion utilities to generate valid .xls or .xlsx outputs from either template type
- Ensure all worksheets are visible before saving to avoid 'At least one sheet must be visible'

## Testing
- `python -m py_compile excel_utils.py`
- `python -m py_compile doc_utils.py parsers.py gui.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6892fd73e60c832785bdbd8db72b3343