### PR TITLE
Handle inline customer address extraction

### DIFF
--- a/parsers.py
+++ b/parsers.py
@@ -193,6 +193,11 @@ def parse_data_from_text(text: str):
                     if len(parts) >= 3:
                         name = "Индивидуальный предприниматель " + " ".join(parts[-3:])
             else:
+                for delim in ["Юридический адрес", "Почтовый адрес"]:
+                    pos = after.find(delim)
+                    if pos != -1:
+                        after = after[:pos].strip()
+                        break
                 name = "Индивидуальный предприниматель " + after
         for j, ln in enumerate(lines_cust):
             if ln.startswith("Юридический адрес"):
@@ -202,6 +207,10 @@ def parse_data_from_text(text: str):
                         address = address.rstrip(",") + ", " + extra
                         break
                 break
+        if not address:
+            addr_match = re.search(r"Юридический адрес[^\n]*(?=\n|Почтовый адрес|$)", block)
+            if addr_match:
+                address = addr_match.group(0).strip()
         if name:
             data["Данные заказчика"] = name
             if address:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import parsers
+
+
+def test_parse_customer_address_inline():
+    text = (
+        "Заказчик: Индивидуальный предприниматель Иванов Иван Иванович "
+        "Юридический адрес: г. Москва, ул. Ленина, д. 1 Почтовый адрес: г. Москва, ул. Ленина, д. 1"
+    )
+    data = parsers.parse_data_from_text(text)
+    assert data["Данные заказчика"] == (
+        "Индивидуальный предприниматель Иванов Иван Иванович\n"
+        "Юридический адрес: г. Москва, ул. Ленина, д. 1"
+    )


### PR DESCRIPTION
## Summary
- Trim customer name before address markers and search for inline `Юридический адрес`
- Append extracted inline address to customer data when not on separate line
- Test parsing when address follows the name without newline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933e163f7c8327ac2294895d1b122e