### PR TITLE
Fix segmentation fault in file dialogs

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -147,7 +147,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def browse_source(self):
         path, _ = QFileDialog.getOpenFileName(
-            self, "Select source", filter="Documents (*.docx *.pdf)"
+            self,
+            "Select source",
+            filter="Documents (*.docx *.pdf)",
+            options=QFileDialog.DontUseNativeDialog,
         )
         if path:
             self.source_edit.setText(path)
@@ -157,7 +160,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def browse_act_template(self):
         path, _ = QFileDialog.getOpenFileName(
-            self, "Select act template", filter="Excel Files (*.xlsx)"
+            self,
+            "Select act template",
+            filter="Excel Files (*.xlsx)",
+            options=QFileDialog.DontUseNativeDialog,
         )
         if path:
             self.settings.setValue("act_template", path)
@@ -166,7 +172,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def browse_invoice_template(self):
         path, _ = QFileDialog.getOpenFileName(
-            self, "Select invoice template", filter="Excel Files (*.xlsx)"
+            self,
+            "Select invoice template",
+            filter="Excel Files (*.xlsx)",
+            options=QFileDialog.DontUseNativeDialog,
         )
         if path:
             self.settings.setValue("invoice_template", path)
@@ -189,6 +198,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self,
             "Save document",
             filter="Excel Workbook (*.xlsx)",
+            options=QFileDialog.DontUseNativeDialog,
         )
         if not output_path:
             return


### PR DESCRIPTION
## Summary
- Ensure QFileDialog is imported in GUI
- Disable native dialogs for all open/save file dialogs to avoid segmentation fault

## Testing
- `python - <<'PY'
import os
os.environ['QT_QPA_PLATFORM']='offscreen'
from PyQt5.QtWidgets import QApplication, QFileDialog
from PyQt5.QtCore import QTimer
app=QApplication([])
QTimer.singleShot(100, app.quit)
try:
    QFileDialog.getOpenFileName(options=QFileDialog.DontUseNativeDialog)
    print('Dialog opened successfully')
except Exception as e:
    print('Error:', e)
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689390a3df708327ba95737eec5fdcb0